### PR TITLE
K8SPXC-643 restart node if it has non-Primary state (#774)

### DIFF
--- a/build/liveness-check.sh
+++ b/build/liveness-check.sh
@@ -34,10 +34,10 @@ else
     MYSQL_CMDLINE="mysql -nNE --connect-timeout=$TIMEOUT ${EXTRA_ARGS}"
 fi
 
-STATUS=$(MYSQL_PWD="${MYSQL_PASSWORD}" $MYSQL_CMDLINE -e 'select 1;' | sed -n -e '2p' | tr '\n' ' ')
+STATUS=$(MYSQL_PWD="${MYSQL_PASSWORD}" $MYSQL_CMDLINE -e 'SHOW GLOBAL STATUS LIKE "wsrep_cluster_status";' | sed -n -e '3p')
 set -x
 
-if [[ "${STATUS}" -eq 1 ]]; then
+if [[ -n "${STATUS}" && "${STATUS}" == 'Primary' ]]; then
     exit 0
 fi
 


### PR DESCRIPTION
* detect split-brain conditions and restart the node to perform auto recovery

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
