### PR TITLE
fix sst thread lost

### DIFF
--- a/build/liveness-check.sh
+++ b/build/liveness-check.sh
@@ -9,7 +9,7 @@ if [ -f /tmp/recovery-case ] || [ -f '/var/lib/mysql/sleep-forever' ]; then
 	exit 0
 fi
 
-if [[ -f '/var/lib/mysql/sst_in_progress' ]] || [[ -f '/var/lib/mysql/wsrep_recovery_verbose.log' ]]; then
+if  s -ef | grep -q "mysql.*sst" || [[ -f '/var/lib/mysql/wsrep_recovery_verbose.log' ]]; then
 	exit 0
 fi
 


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
After the PXC instance is started, there is a POD that cannot join the cluster.

**Cause:**
During PXC instance startup, the SST process within the POD is abnormally interrupted. When checking the POD, the SST process cannot be found, but the sst_in_progress file is present. The liveness-check.sh script does not detect any exceptions and does not trigger a POD restart.

**Solution:**
Change the check from sst_in_progress to SST process.